### PR TITLE
alpha 0.3.1

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
 tmp
 tests/
-Brocfile.js
 gulpfile.js

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "content-kit-compiler",
-  "version": "0.2.3",
+  "version": "0.3.1",
   "description": "Parses and renders content to and from the JSON model that backs ContentKit's WYSIWYG Editor",
   "repository": "https://github.com/bustlelabs/content-kit-compiler",
   "main": "dist/content-kit-compiler/index.js",
   "scripts": {
     "test": "testem ci",
     "build": "rm -rf dist && broccoli build dist",
-    "prepublish": "npm run build",
+    "prepublish": "./scripts/build-if-necessary.sh",
     "serve": "brocolli serve"
   },
   "keywords": [
@@ -35,7 +35,6 @@
     "gulp-file": "^0.2.0",
     "gulp-jshint": "^1.10.0",
     "gulp-qunit": "^1.2.1",
-    "qunit": "^0.7.6",
     "qunitjs": "^1.18.0",
     "testem": "^0.8.4"
   }

--- a/scripts/build-if-necessary.sh
+++ b/scripts/build-if-necessary.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ ! -d ./dist ]; then
+  npm run build
+fi


### PR DESCRIPTION
bumps to 0.3.1 (I accidentally made a `0.3.0` tag), stops ignoring the `Brocfile.js` and adds a script that avoids building when `dist/` already exists (because `prepublish` will run when an upstream consumer runs `npm install`)

@mixonic this is necessary for `content-kit-editor` (https://github.com/bustlelabs/content-kit-editor/pull/9)